### PR TITLE
Check request body instead of Content-Type header

### DIFF
--- a/src/Http/ValidateIsJsonMiddleware.php
+++ b/src/Http/ValidateIsJsonMiddleware.php
@@ -16,7 +16,8 @@ class ValidateIsJsonMiddleware
     public function handle($request, Closure $next)
     {
         if ($request->isMethod('POST') || $request->isMethod('PUT')) {
-            if ( ! $request->isJson() ) {
+            json_decode($request->getContent());
+            if (json_last_error() != JSON_ERROR_NONE) {
                 return response()->json("Request must be json", 400);
             }
         }


### PR DESCRIPTION
- We're blocking valid requests that are missing a `Content-Type` header. Noticed this because Amazon SNS requests don't have the header.
